### PR TITLE
Use `namespace` runners

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -6,7 +6,7 @@ on:
     - cron: '*/10 * * * *'
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: nscloud
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
see:
* https://nix-community.org/continuous-integration/
* https://cloud.namespace.so/docs/features/faster-github-actions

I don't want to "fix" the workflow for running on PRs, so I'm going to merge this and iterate on master.