### PR TITLE
github: workflow: limit workflow run to 10 minutes

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -6,6 +6,7 @@ on:
     - cron: '*/60 * * * *'
 jobs:
   update:
+    timeout-minutes: 10
     runs-on: nscloud-ubuntu-22.04-amd64-4x16
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
- it seems like something times out the looping test after 20 minutes
- however, the update + test shouldn't really take more than 10 minutes
- thus, this should cut our builder minutes in half, in the meantime