### PR TITLE
I hyperfocused and rewrote the whole thing

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "cachix": {
-      "locked": {
-        "lastModified": 1635350005,
-        "narHash": "sha256-tAMJnUwfaDEB2aa31jGcu7R7bzGELM9noc91L2PbVjg=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "1c1f5649bb9c1b0d98637c8c365228f57126f361",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-20.09",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "locked": {
         "lastModified": 1717312683,
@@ -68,34 +52,18 @@
         "type": "github"
       }
     },
-    "mozilla": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1740762144,
-        "narHash": "sha256-I7a6e3IYJAp9u3PwUSW1+oilO1tAfnbeN3/YJQ+ObCo=",
-        "owner": "mozilla",
-        "repo": "nixpkgs-mozilla",
-        "rev": "e35b0e071cae97469d80222be988fdd972b22c3b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mozilla",
-        "repo": "nixpkgs-mozilla",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741513245,
-        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "lastModified": 1741715534,
+        "narHash": "sha256-IDtwLhWMKvydW9GrB6ETwhij+vma0hYHln8pR/rTd+U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "rev": "0d534853a55b5d02a4ababa1d71921ce8f0aee4c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -117,10 +85,8 @@
     },
     "root": {
       "inputs": {
-        "cachix": "cachix",
         "flake-compat": "flake-compat",
         "lib-aggregate": "lib-aggregate",
-        "mozilla": "mozilla",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,85 +2,119 @@
   description = "firefox-nightly";
 
   inputs = {
-    nixpkgs = { url = "github:nixos/nixpkgs/nixos-unstable"; };
-    lib-aggregate = { url = "github:nix-community/lib-aggregate"; };
-    cachix = { url = "github:nixos/nixpkgs/nixos-20.09"; };
-    mozilla = { url = "github:mozilla/nixpkgs-mozilla"; flake = false; };
-    flake-compat = { url = "github:nix-community/flake-compat"; };
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable-small";
+    lib-aggregate.url = "github:nix-community/lib-aggregate";
+    flake-compat.url = "github:nix-community/flake-compat";
   };
 
-  outputs = inputs:
+  outputs =
+    inputs:
     let
       inherit (inputs.lib-aggregate) lib;
-      inherit (inputs) self;
-      metadata = builtins.fromJSON (builtins.readFile ./latest.json);
+      versions = builtins.fromJSON (builtins.readFile ./latest.json);
 
-      mozillaSystemDict = {
-        "x86_64-linux" = "linux-x86_64";
-        "aarch64-linux" = "linux-aarch64"; # TODO: doesn't work since Moz doesn't publish 'em
-      };
-
-      # supportedSystems = [ "x86_64-linux" "aarch64-linux" ]; # TODO: still not there
-      supportedSystems = [ "x86_64-linux" ];
-
-    in
-    lib.flake-utils.eachSystem supportedSystems (system:
-      let
-        pkgsFor = pkgs: overlays:
-          import pkgs {
-            inherit system;
-            config.allowUnfree = true;
-            overlays = [ (import "${inputs.mozilla}/firefox-overlay.nix") ];
-          };
-
-        pkgs_ = lib.genAttrs (builtins.attrNames inputs) (inp: pkgsFor inputs."${inp}" [ ]);
-
-        fv = pkgs_.nixpkgs.lib.firefoxOverlay.firefoxVariants;
-        variants = (builtins.mapAttrs
-          (n: v:
+      overlay =
+        final: prev:
+        let
+          mkFirefox =
+            {
+              branch,
+              name,
+              channel ? "release",
+            }:
             let
-              cv = metadata.${system}."variants".${n};
-              cvi = metadata.${system}."versionInfo".${n};
+              inherit (final.stdenv.hostPlatform) system;
+
+              # map nixpkgs systems to mozilla
+              mozSystem =
+                {
+                  "x86_64-linux" = "linux-x86_64";
+                  "aarch64-linux" = "linux-aarch64";
+                }
+                .${system};
+
+              data = versions.${mozSystem}.${branch};
+
+              # compatibility with nixpkgs 24.11 and 25.05
+              applicationNameArg =
+                let
+                  args = lib.functionArgs final.firefox-bin-unwrapped.override;
+                in
+                if args ? "applicationName" then "applicationName" else "desktopName";
+
+              unwrapped =
+                if isNull data then
+                  throw "${name} is not available on ${system}!"
+                else
+                  (final.firefox-bin-unwrapped.override {
+                    inherit channel;
+                    ${applicationNameArg} = name;
+                    generated.version = data.version;
+                  }).overrideAttrs
+                    {
+                      src = final.fetchurl {
+                        inherit (data) url hash;
+                      };
+                    };
             in
-            pkgs_.nixpkgs.lib.firefoxOverlay.firefoxVersion (cv // { info = cvi; })
-          )
-          (fv)
-        );
-
-        # latest versionInfo outputs for each variant
-        # impure, but by design. this is stored/recorded and then used purely
-        impureVariants =
-          (pkgs_.nixpkgs.lib.firefoxOverlay.firefoxVariants);
-
-        impureVersionInfos = (builtins.mapAttrs
-          (n: v: pkgs_.nixpkgs.lib.firefoxOverlay.versionInfo (v // { system = mozillaSystemDict.${system}; }))
-          (fv)
-        );
-
-        # https://nixos.org/manual/nixos/unstable/index.html#sec-calling-nixos-tests
-        nixos-lib = import (inputs.nixpkgs + "/nixos/lib") { };
-        runNixOSTestFor = pkg: nixos-lib.runTest {
-          imports = [ ./tests/firefox.nix ];
-          hostPkgs = pkgs_.nixpkgs;
-          defaults = {
-            # reuse the already evaluated nixpkgs
-            # https://search.nixos.org/options?channel=unstable&show=nixpkgs.pkgs
-            # with 3.9 s without 4.9 s both with a dirty tree
-            # `time nix build ".#checks.x86_64-linux.firefox-bin"`
-            nixpkgs.pkgs = pkgs_.nixpkgs;
-            # Less dependencies
-            documentation.enable = false;
+            final.wrapFirefox unwrapped {
+              pname = "${unwrapped.binaryName}-bin";
+            };
+        in
+        {
+          firefox-bin = mkFirefox {
+            branch = "release";
+            name = "Firefox";
           };
-          _module.args.firefoxPackage = pkg;
+
+          firefox-esr-bin = mkFirefox {
+            branch = "esr";
+            name = "Firefox ESR";
+          };
+
+          firefox-beta-bin = mkFirefox {
+            branch = "beta";
+            name = "Firefox Beta";
+            channel = "beta";
+          };
+
+          firefox-nightly-bin = mkFirefox {
+            branch = "nightly";
+            name = "Firefox Nightly";
+            channel = "nightly";
+          };
         };
 
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+
+    in
+    {
+      overlays.default = overlay;
+    }
+    // (lib.flake-utils.eachSystem supportedSystems (
+      system:
+      let
+        pkgs = import inputs.nixpkgs { inherit system; };
+
+        firefoxPkgs = overlay pkgs pkgs;
+
+        # https://nixos.org/manual/nixos/unstable/index.html#sec-calling-nixos-tests
+        runNixOSTestFor =
+          pkg:
+          pkgs.testers.runNixOSTest {
+            imports = [ ./tests/firefox.nix ];
+            defaults = {
+              # Less dependencies
+              documentation.enable = false;
+            };
+            _module.args.firefoxPackage = pkg;
+          };
       in
       {
         devShells = {
-          default = pkgs_.nixpkgs.mkShell {
-            nativeBuildInputs = [ ]
-              ++ (with pkgs_.cachix; [ cachix ])
-              ++ (with pkgs_.nixpkgs; [
+          default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              cachix
               nixVersions.latest
               nix-prefetch
               nix-build-uncached
@@ -93,25 +127,20 @@
               nushell
               openssh
               ripgrep
-            ])
-            ;
+            ];
           };
         };
 
-        packages = ({
-          default = pkgs_.nixpkgs.linkFarm "firefox-variants" [
-            { name = "firefox-bin"; path = variants.firefox-bin; }
-            { name = "firefox-esr-bin"; path = variants.firefox-esr-bin; }
-            { name = "firefox-nightly-bin"; path = variants.firefox-nightly-bin; }
-            { name = "firefox-beta-bin"; path = variants.firefox-beta-bin; }
-          ];
-        } // variants);
-
-        latest = {
-          variants = impureVariants;
-          versionInfo = impureVersionInfos;
+        packages = firefoxPkgs // {
+          default = pkgs.linkFarm "firefox-variants" (
+            lib.mapAttrsToList (name: value: {
+              inherit name;
+              path = value;
+            }) firefoxPkgs
+          );
         };
 
-        checks = builtins.mapAttrs (_: value: runNixOSTestFor value) (builtins.removeAttrs self.packages.${system} [ "default" ]) /* # is a link farm */ ;
-      });
+        checks = builtins.mapAttrs (_: value: runNixOSTestFor value) firefoxPkgs;
+      }
+    ));
 }

--- a/generate.nu
+++ b/generate.nu
@@ -1,0 +1,70 @@
+#!/usr/bin/env nu
+const SYSTEMS = ["linux-x86_64" "linux-aarch64"];
+
+def to_sri (hash: string) {
+  return $"sha512-($hash | decode hex | encode base64)"
+}
+
+def fetch_release (version: string, system: string, extension: string) {
+  let base = $"https://download.cdn.mozilla.net/pub/firefox/releases/($version)"
+
+  let filename = $"($system)/en-US/firefox-($version).($extension)"
+
+  let row = (
+    http get $"($base)/SHA512SUMS"
+    | from ssv -m 1 --noheaders
+    | where column1 == $filename
+  )
+
+  if ($row | is-not-empty) {
+    let hash = $row.column0.0
+
+    return {
+      version: $version,
+      url: $"($base)/($filename)",
+      hash: (to_sri $hash)
+    }  
+  } else {
+    return null
+  }
+}
+
+def fetch_nightly (version: string, system: string) {
+  let product = $"firefox-($version).en-US.($system)";
+  let data = http get $"https://download.cdn.mozilla.net/pub/firefox/nightly/latest-mozilla-central/($product).buildhub.json";
+  
+  let url = $data.download.url
+
+  let hash = (
+    http get $"($url | path dirname)/($product).checksums"
+    | from ssv -m 1 --noheaders
+    | where column1 == "sha512"
+    | where column3 == ($url | path basename)
+  ).column0.0
+
+  return {
+    version: $version,
+    url: $url,
+    hash: (to_sri $hash),
+    date: $data.build.date,
+  }
+}
+
+let versions = (http get "https://product-details.mozilla.org/1.0/firefox_versions.json")
+
+let data = (
+  $SYSTEMS
+  | wrap system
+  | each {|it| {
+    system: $it.system,
+    data: {
+      release: (fetch_release $versions.LATEST_FIREFOX_VERSION $it.system "tar.xz")
+      esr: (fetch_release $versions.FIREFOX_ESR $it.system "tar.bz2")
+      beta: (fetch_release $versions.LATEST_FIREFOX_RELEASED_DEVEL_VERSION $it.system "tar.xz")
+      nightly: (fetch_nightly $versions.FIREFOX_NIGHTLY $it.system)
+    }
+  }}
+  | transpose --header-row --as-record
+)
+
+$data | to json | save -f latest.json

--- a/latest.json
+++ b/latest.json
@@ -1,77 +1,44 @@
 {
-  "x86_64-linux": {
-    "variants": {
-      "firefox-beta-bin": {
-        "channel": "beta",
-        "name": "Firefox Beta",
-        "release": true,
-        "version": "137.0b4",
-        "wmClass": "firefox-beta"
-      },
-      "firefox-bin": {
-        "channel": "release",
-        "name": "Firefox",
-        "release": true,
-        "version": "136.0.1",
-        "wmClass": "firefox"
-      },
-      "firefox-esr-bin": {
-        "channel": "release",
-        "name": "Firefox ESR",
-        "release": true,
-        "version": "128.8.0esr",
-        "wmClass": "firefox"
-      },
-      "firefox-nightly-bin": {
-        "channel": "nightly",
-        "name": "Firefox Nightly",
-        "release": false,
-        "version": "138.0a1",
-        "wmClass": "firefox-nightly"
-      }
+  "linux-x86_64": {
+    "release": {
+      "version": "136.0.1",
+      "url": "https://download.cdn.mozilla.net/pub/firefox/releases/136.0.1/linux-x86_64/en-US/firefox-136.0.1.tar.xz",
+      "hash": "sha512-s6bYfMoD+RsUrMeCPU4dQi6JLFjJR1AElL7iQuiXQk99t5j7/CBLVwTpgJwWLymm74crj2RFAG8f1UYLd86qsQ=="
     },
-    "versionInfo": {
-      "firefox-beta-bin": {
-        "chksum": "https://download.cdn.mozilla.net/pub/firefox/releases/137.0b4/SHA512SUMS",
-        "chksumSha256": "93b0579ea478be5d53bb773d4f87f3e71843adadeb87bd5edbf8223baaf59a3a",
-        "chksumSig": "https://download.cdn.mozilla.net/pub/firefox/releases/137.0b4/SHA512SUMS.asc",
-        "chksumSigSha256": "b3eecafee0175be6742f841297b31b3bb120ca4e0c00f5ee4dc6e98fbcabbc6b",
-        "file": "linux-x86_64/en-US/firefox-137.0b4.tar.xz",
-        "sha512": "e79254a6fd24bc7dc9ac8ceaa4be2c532a02e3cb28804290caa929e5d4cfa4b989340dab613f3868e272e85108cebf6fdd725d54e40e66d693bf8e1cbf35e57f",
-        "sig": null,
-        "sigSha512": null,
-        "url": "https://download.cdn.mozilla.net/pub/firefox/releases/137.0b4/linux-x86_64/en-US/firefox-137.0b4.tar.xz"
-      },
-      "firefox-bin": {
-        "chksum": "https://download.cdn.mozilla.net/pub/firefox/releases/136.0.1/SHA512SUMS",
-        "chksumSha256": "a3f5c70c20f0fc58b726205f539b08b632d01332d35b65bf35603caf29aa6c88",
-        "chksumSig": "https://download.cdn.mozilla.net/pub/firefox/releases/136.0.1/SHA512SUMS.asc",
-        "chksumSigSha256": "6162173af567d9d74d6ee09a08467a8d3283b400687329014d9026dcb0dc5797",
-        "file": "linux-x86_64/en-US/firefox-136.0.1.tar.xz",
-        "sha512": "b3a6d87cca03f91b14acc7823d4e1d422e892c58c947500494bee242e897424f7db798fbfc204b5704e9809c162f29a6ef872b8f6445006f1fd5460b77ceaab1",
-        "sig": null,
-        "sigSha512": null,
-        "url": "https://download.cdn.mozilla.net/pub/firefox/releases/136.0.1/linux-x86_64/en-US/firefox-136.0.1.tar.xz"
-      },
-      "firefox-esr-bin": {
-        "chksum": "https://download.cdn.mozilla.net/pub/firefox/releases/128.8.0esr/SHA512SUMS",
-        "chksumSha256": "73c792b4f8b83df6d7d92237cd748e76ab6dd988661474b9a3f413c1c1dfd004",
-        "chksumSig": "https://download.cdn.mozilla.net/pub/firefox/releases/128.8.0esr/SHA512SUMS.asc",
-        "chksumSigSha256": "5896171056c03b524232bdef5aedf7f517d5bae429dbc6ddbc75bf6c6cf4f6fc",
-        "file": "linux-x86_64/en-US/firefox-128.8.0esr.tar.bz2",
-        "sha512": "0bba45e6089adf319983d539001d1bbb807ccd3cde99e467d0a938821c1192e93dcddd162ba36b55903af7cb35f574e2b5d3e9bca09047cd0e4d89d37dcb945e",
-        "sig": null,
-        "sigSha512": null,
-        "url": "https://download.cdn.mozilla.net/pub/firefox/releases/128.8.0esr/linux-x86_64/en-US/firefox-128.8.0esr.tar.bz2"
-      },
-      "firefox-nightly-bin": {
-        "chksum": "https://archive.mozilla.org/pub/firefox/nightly/2025/03/2025-03-11-21-27-27-mozilla-central/firefox-138.0a1.en-US.linux-x86_64.checksums",
-        "chksumSig": null,
-        "sha512": "042ed920c71a7f4939c66430b8b1d5897731400667da41c3e9999ca337e271cee2dda5e6276f30cc118d443d181527239bade3de1f01612bec1607645b1c0ca5",
-        "sig": "https://archive.mozilla.org/pub/firefox/nightly/2025/03/2025-03-11-21-27-27-mozilla-central/firefox-138.0a1.en-US.linux-x86_64.tar.xz.asc",
-        "sigSha512": "07a0f7357c361248693fbd7ce7919ef4c3130d513948e26fdd5db1efea08b47b321a5a58fa1bf5af70c17c65e9b5edc64e6a12aebce86533699605e88dc4c945",
-        "url": "https://archive.mozilla.org/pub/firefox/nightly/2025/03/2025-03-11-21-27-27-mozilla-central/firefox-138.0a1.en-US.linux-x86_64.tar.xz"
-      }
+    "esr": {
+      "version": "128.8.0esr",
+      "url": "https://download.cdn.mozilla.net/pub/firefox/releases/128.8.0esr/linux-x86_64/en-US/firefox-128.8.0esr.tar.bz2",
+      "hash": "sha512-C7pF5gia3zGZg9U5AB0bu4B8zTzemeRn0Kk4ghwRkuk9zd0WK6NrVZA698s19XTitdPpvKCQR80OTYnTfcuUXg=="
+    },
+    "beta": {
+      "version": "137.0b4",
+      "url": "https://download.cdn.mozilla.net/pub/firefox/releases/137.0b4/linux-x86_64/en-US/firefox-137.0b4.tar.xz",
+      "hash": "sha512-55JUpv0kvH3JrIzqpL4sUyoC48sogEKQyqkp5dTPpLmJNA2rYT84aOJy6FEIzr9v3XJdVOQOZtaTv44cvzXlfw=="
+    },
+    "nightly": {
+      "version": "138.0a1",
+      "url": "https://archive.mozilla.org/pub/firefox/nightly/2025/03/2025-03-11-21-27-27-mozilla-central/firefox-138.0a1.en-US.linux-x86_64.tar.xz",
+      "hash": "sha512-BC7ZIMcaf0k5xmQwuLHViXcxQAZn2kHD6Zmcozficc7i3aXmJ28wzBGNRD0YFScjm63j3h8BYSvsFgdkWxwMpQ==",
+      "date": "2025-03-11T21:27:27Z"
+    }
+  },
+  "linux-aarch64": {
+    "release": {
+      "version": "136.0.1",
+      "url": "https://download.cdn.mozilla.net/pub/firefox/releases/136.0.1/linux-aarch64/en-US/firefox-136.0.1.tar.xz",
+      "hash": "sha512-oKWfhljJNJjw8tW9Cy3C6Z0b2vfe2OcVGOk8bfTK0Wxm9vYOqIUwXrMxyZAUB4YXK9o3TAJtuHW9K6kpPEbD7A=="
+    },
+    "esr": null,
+    "beta": {
+      "version": "137.0b4",
+      "url": "https://download.cdn.mozilla.net/pub/firefox/releases/137.0b4/linux-aarch64/en-US/firefox-137.0b4.tar.xz",
+      "hash": "sha512-dFfejPiHb4dpLkk2iTHCNNCQe2TpT96AvP2IX/kkVaqx5MRa4OewmjGT9YA/fLf8ZD11zYFoehGt6aT7ywUJeQ=="
+    },
+    "nightly": {
+      "version": "138.0a1",
+      "url": "https://archive.mozilla.org/pub/firefox/nightly/2025/03/2025-03-11-21-27-27-mozilla-central/firefox-138.0a1.en-US.linux-aarch64.tar.xz",
+      "hash": "sha512-kFXf+h7UbTXHDSaCYBh1eeUO6ZkQahdXRbU5wfqOtAZ0nobCxMr5qG4qSukUMHmZ/PJuKQHTFwdb/JqeUsStPQ==",
+      "date": "2025-03-11T21:27:27Z"
     }
   }
 }

--- a/update.nu
+++ b/update.nu
@@ -1,29 +1,20 @@
 #!/usr/bin/env nu
-
-let DIR = ($env.FILE_PWD)
-let cache = "nixpkgs-wayland"
-
 print -e $"::group::flake-lock-update"
 do {
-  nix flake lock --recreate-lock-file --commit-lock-file
+  nix flake lock --commit-lock-file
 }
 print -e $"::endgroup::"
 
 print -e $"::group::firefox-update"
 let commitmsg = do {
-  let oldversion = (cat latest.json
-    | jq -r '.["x86_64-linux"].versionInfo["firefox-nightly-bin"].chksum'
-    | grep -Eo '[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}')
+  let oldversion = (cat latest.json | jq -r '."linux-x86_64".nightly.date')
   
   print -e $"::notice ::oldversion=($oldversion)"
+
+  ./generate.nu
   
-  rm latest.json
-  nix eval --impure '.#latest' --json | jq out> latest.json
-  
-  let newversion = (cat latest.json
-    | jq -r '.["x86_64-linux"].versionInfo["firefox-nightly-bin"].chksum'
-    | grep -Eo '[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}')
-  
+  let newversion = (cat latest.json | jq -r '."linux-x86_64".nightly.date')
+
   print -e $"::notice ::newversion=($newversion)"
 
   $"firefox-nightly-bin: ($oldversion) -> ($newversion)"

--- a/update.nu
+++ b/update.nu
@@ -1,7 +1,7 @@
 #!/usr/bin/env nu
 print -e $"::group::flake-lock-update"
 do {
-  nix flake lock --commit-lock-file
+  nix flake update --commit-lock-file
 }
 print -e $"::endgroup::"
 


### PR DESCRIPTION
Oops.

Actual changes:
- get rid of nixpkgs-mozilla dependency
- reimplement all the version updating logic locally in nushell
- make the flake export an overlay by default
- be compatible with latest nixpkgs