### PR TITLE
Fix build for removal of firefox-{beta,devedition}-bin from nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,14 +37,16 @@
 
               # compatibility with nixpkgs 24.11 and 25.05
               pr377863 = lib.functionArgs final.firefox-bin-unwrapped.override ? "applicationName";
+              pr414510 = !lib.functionArgs final.firefox-bin-unwrapped.override ? "channel";
 
               unwrapped =
                 if isNull data then
                   throw "${name} is not available on ${system}!"
                 else
                   (final.firefox-bin-unwrapped.override ({
-                    inherit channel;
                     generated.version = data.version;
+                  } // lib.optionalAttrs (!pr414510) {
+                    inherit channel;
                   } // lib.optionalAttrs pr377863 {
                     applicationName = name;
                   })).overrideAttrs


### PR DESCRIPTION
```
error: function 'anonymous lambda' called with unexpected argument 'channel' at /nix/store/ny8c07vsrfwcb1c4i3jcpbi3qi4w9wy6-source/pkgs/applications/networking/browsers/firefox-bin/default.nix:1:1
```

- https://github.com/NixOS/nixpkgs/pull/414510